### PR TITLE
feat: AskUserQuestion, plan mode, usage fix, auto-naming

### DIFF
--- a/src/claude-transport.ts
+++ b/src/claude-transport.ts
@@ -155,6 +155,7 @@ export class ClaudeTransport {
     requestId: string,
     behavior: "allow" | "allow_always" | "deny",
     toolName?: string,
+    updatedInput?: Record<string, unknown>,
   ): void {
     if (!this.proc?.stdin?.writable) return;
 
@@ -172,7 +173,7 @@ export class ClaudeTransport {
       // via the updatedPermissions array on an "allow" response.
       response = {
         behavior: "allow",
-        updatedInput: {},
+        updatedInput: updatedInput || {},
         decisionClassification: "user_permanent",
         updatedPermissions: [
           {
@@ -186,7 +187,7 @@ export class ClaudeTransport {
     } else {
       response = {
         behavior: "allow",
-        updatedInput: {},
+        updatedInput: updatedInput || {},
         decisionClassification: "user_temporary",
       };
     }

--- a/src/components/AskQuestion.tsx
+++ b/src/components/AskQuestion.tsx
@@ -3,7 +3,7 @@ import type { AskQuestionData } from "../hooks/useChatEngine";
 
 interface AskQuestionProps {
   question: AskQuestionData;
-  onAnswer: (questionId: string, answer: string) => void;
+  onAnswer: (questionId: string, answers: Record<string, string>) => void;
 }
 
 export function AskQuestion({ question, onAnswer }: AskQuestionProps) {
@@ -21,75 +21,95 @@ export function AskQuestion({ question, onAnswer }: AskQuestionProps) {
 
       const allDone = questions.every((_, i) => newAnswers[i]);
       if (allDone) {
-        const answerText =
-          questions.length === 1
-            ? newAnswers[0]
-            : questions
-                .map((q, i) => `${q.question}: ${newAnswers[i]}`)
-                .join("\n");
-        onAnswer(question.id, answerText);
+        const answerMap: Record<string, string> = {};
+        questions.forEach((q, i) => {
+          answerMap[q.question] = newAnswers[i];
+        });
+        onAnswer(question.id, answerMap);
       }
     },
     [answers, questions, question.id, onAnswer]
   );
 
   return (
-    <div className="hyo-ask-question">
-      {questions.map((q, i) => (
-        <div key={i} className="hyo-ask-question-item">
-          {q.header && (
-            <div className="hyo-ask-question-header">{q.header}</div>
-          )}
-          <div className="hyo-ask-question-text">{q.question}</div>
+    <div className="hyo-ask">
+      {questions.map((q, i) => {
+        const isActive = i === currentIdx;
+        const isAnswered = !!answers[i];
+        const isPending = !isActive && !isAnswered;
 
-          {answers[i] ? (
-            <div className="hyo-ask-question-answered">{answers[i]}</div>
-          ) : i === currentIdx ? (
-            <div className="hyo-ask-question-input">
-              {q.options && q.options.length > 0 && (
-                <div className="hyo-ask-question-options">
-                  {q.options.map((opt, oi) => (
-                    <button
-                      key={oi}
-                      className="hyo-ask-option"
-                      onClick={() => submitAnswer(i, opt.label)}
-                    >
-                      {opt.label}
-                      {opt.description && (
-                        <span className="hyo-ask-option-desc">
-                          {opt.description}
-                        </span>
-                      )}
-                    </button>
-                  ))}
-                  <div className="hyo-ask-or">or</div>
-                </div>
+        return (
+          <div
+            key={i}
+            className={`hyo-ask-item ${isActive ? "is-active" : ""} ${isAnswered ? "is-answered" : ""} ${isPending ? "is-pending" : ""}`}
+          >
+            <div className="hyo-ask-item-header">
+              {q.header && <span className="hyo-ask-chip">{q.header}</span>}
+              {isAnswered && (
+                <span className="hyo-ask-answered-badge">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  {answers[i]}
+                </span>
               )}
-              <div className="hyo-ask-text-input">
-                <input
-                  type="text"
-                  value={inputValue}
-                  onChange={(e) => setInputValue(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && inputValue.trim()) {
-                      submitAnswer(i, inputValue.trim());
-                    }
-                  }}
-                  placeholder="Type your answer..."
-                />
-                <button
-                  onClick={() =>
-                    inputValue.trim() && submitAnswer(i, inputValue.trim())
-                  }
-                  disabled={!inputValue.trim()}
-                >
-                  Send
-                </button>
-              </div>
             </div>
-          ) : null}
-        </div>
-      ))}
+
+            <div className="hyo-ask-question-text">{q.question}</div>
+
+            {isActive && (
+              <div className="hyo-ask-controls">
+                {q.options && q.options.length > 0 && (
+                  <>
+                    <div className="hyo-ask-options">
+                      {q.options.map((opt, oi) => (
+                        <button
+                          key={oi}
+                          className="hyo-ask-opt"
+                          onClick={() => submitAnswer(i, opt.label)}
+                        >
+                          <span className="hyo-ask-opt-label">{opt.label}</span>
+                          {opt.description && (
+                            <span className="hyo-ask-opt-desc">{opt.description}</span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="hyo-ask-divider">
+                      <span>or type your own</span>
+                    </div>
+                  </>
+                )}
+                <div className="hyo-ask-input">
+                  <input
+                    type="text"
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && inputValue.trim()) {
+                        submitAnswer(i, inputValue.trim());
+                      }
+                    }}
+                    placeholder={q.options?.length ? "Other..." : "Type your answer..."}
+                    autoFocus
+                  />
+                  <button
+                    className="hyo-ask-send"
+                    onClick={() => inputValue.trim() && submitAnswer(i, inputValue.trim())}
+                    disabled={!inputValue.trim()}
+                    aria-label="Send"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <line x1="22" y1="2" x2="11" y2="13" />
+                      <polygon points="22 2 15 22 11 13 2 9 22 2" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { ToolCall } from "./ToolCall";
+import { AskQuestion } from "./AskQuestion";
+import { PlanReview } from "./PlanReview";
 import { MarkdownBlock, stripInlineThinkingTags } from "./MarkdownBlock";
 import type { Message } from "../hooks/useChatEngine";
 import { HIDDEN_TOOLS } from "../hooks/useChatEngine";
@@ -8,9 +10,11 @@ import { THINKING_BLOCK_ERROR_RE } from "../session-repair";
 interface ChatMessageProps {
   message: Message;
   onRecover?: () => void;
+  onPermissionResponse?: (requestId: string, behavior: "allow" | "allow_always" | "deny") => void;
+  onQuestionAnswer?: (questionId: string, answers: Record<string, string>) => void;
 }
 
-export function ChatMessage({ message, onRecover }: ChatMessageProps) {
+export function ChatMessage({ message, onRecover, onPermissionResponse, onQuestionAnswer }: ChatMessageProps) {
   if (message.isCompaction) {
     return <CompactionMessage message={message} />;
   }
@@ -18,7 +22,14 @@ export function ChatMessage({ message, onRecover }: ChatMessageProps) {
     return <UserMessage message={message} />;
   }
   if (message.role === "assistant") {
-    return <AssistantMessage message={message} onRecover={onRecover} />;
+    return (
+      <AssistantMessage
+        message={message}
+        onRecover={onRecover}
+        onPermissionResponse={onPermissionResponse}
+        onQuestionAnswer={onQuestionAnswer}
+      />
+    );
   }
   return null;
 }
@@ -117,7 +128,12 @@ function isThinkingBlockErrorContent(text: string): boolean {
   return THINKING_BLOCK_ERROR_RE.test(text);
 }
 
-function AssistantMessage({ message, onRecover }: { message: Message; onRecover?: () => void }) {
+function AssistantMessage({ message, onRecover, onPermissionResponse, onQuestionAnswer }: {
+  message: Message;
+  onRecover?: () => void;
+  onPermissionResponse?: (requestId: string, behavior: "allow" | "allow_always" | "deny") => void;
+  onQuestionAnswer?: (questionId: string, answers: Record<string, string>) => void;
+}) {
   const blocks = message.orderedBlocks || [];
   const toolCalls = message.toolCalls || [];
 
@@ -188,6 +204,26 @@ function AssistantMessage({ message, onRecover }: { message: Message; onRecover?
           }
           return null;
         })}
+
+        {message.askQuestion && onQuestionAnswer && (
+          <AskQuestion
+            question={message.askQuestion}
+            onAnswer={onQuestionAnswer}
+          />
+        )}
+
+        {message.planReview && !message.planReview.resolved && onPermissionResponse && (
+          <PlanReview
+            review={message.planReview}
+            onRespond={onPermissionResponse}
+          />
+        )}
+        {message.planReview?.resolved && (
+          <PlanReview
+            review={message.planReview}
+            onRespond={() => {}}
+          />
+        )}
       </div>
       {showRecover && onRecover && <RecoverBanner onRecover={onRecover} />}
       {!message.streaming && blocks.some((b) => b.type === "text") && (

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -7,7 +7,7 @@ interface ChatMessagesProps {
   messages: Message[];
   scrollRef: React.MutableRefObject<{ nearBottom: boolean }>;
   onPermissionResponse: (requestId: string, behavior: "allow" | "allow_always" | "deny") => void;
-  onQuestionAnswer: (questionId: string, answer: string) => void;
+  onQuestionAnswer: (questionId: string, answers: Record<string, string>) => void;
   onRecover?: () => void;
 }
 
@@ -64,7 +64,15 @@ export function ChatMessages({
           );
         }
 
-        return <ChatMessage key={`msg-${i}`} message={msg} onRecover={onRecover} />;
+        return (
+          <ChatMessage
+            key={`msg-${i}`}
+            message={msg}
+            onRecover={onRecover}
+            onPermissionResponse={onPermissionResponse}
+            onQuestionAnswer={onQuestionAnswer}
+          />
+        );
       })}
     </div>
   );

--- a/src/components/HyoStatusBar.tsx
+++ b/src/components/HyoStatusBar.tsx
@@ -98,6 +98,7 @@ export function HyoStatusBar({
     sessionPacePct,
     weeklyPacePct,
     lastUpdated,
+    stale,
     refresh,
   } = useUsage();
 
@@ -192,8 +193,8 @@ export function HyoStatusBar({
     <div className="hyo-status-bar" ref={statusBarRef}>
       <div
         ref={usageRef}
-        className="hyo-usage-bars-group"
-        title="Usage"
+        className={`hyo-usage-bars-group${stale ? " stale" : ""}`}
+        title={stale ? "Usage data may be outdated — click to refresh" : "Usage"}
         onClick={() => openPopup("usage")}
       >
         <span className="hyo-usage-bar-label">5HR</span>
@@ -398,6 +399,11 @@ export function HyoStatusBar({
             </>
           )}
           <div className="hyo-usage-divider" />
+          {stale && (
+            <div className="hyo-usage-stale-notice">
+              ⚠ Couldn't fetch usage data. Try refreshing — if it persists, open the Claude desktop app to re-authenticate.
+            </div>
+          )}
           <button className="hyo-usage-refresh-btn" onClick={refresh}>
             Refresh · Last updated{" "}
             {lastUpdated ? formatTimeAgo(lastUpdated) : "never"}

--- a/src/components/PlanReview.tsx
+++ b/src/components/PlanReview.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { MarkdownBlock } from "./MarkdownBlock";
+import type { PlanReviewData } from "../hooks/useChatEngine";
+
+interface PlanReviewProps {
+  review: PlanReviewData;
+  onRespond: (requestId: string, behavior: "allow" | "allow_always" | "deny") => void;
+}
+
+export function PlanReview({ review, onRespond }: PlanReviewProps) {
+  const { requestId, planContent, allowedPrompts, resolved } = review;
+
+  if (resolved) {
+    return (
+      <div className="hyo-plan-review hyo-plan-review-resolved">
+        <div className="hyo-plan-review-status">
+          {resolved === "approved" ? "✓ Plan approved" : "✗ Plan rejected"}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hyo-plan-review">
+      <div className="hyo-plan-review-header">Plan ready for review</div>
+
+      {planContent ? (
+        <div className="hyo-plan-review-content">
+          <MarkdownBlock content={planContent} />
+        </div>
+      ) : (
+        <div className="hyo-plan-review-fallback">
+          Review the plan in the conversation above.
+        </div>
+      )}
+
+      {allowedPrompts.length > 0 && (
+        <div className="hyo-plan-review-permissions">
+          <div className="hyo-plan-review-permissions-label">
+            This plan needs permission to:
+          </div>
+          <ul>
+            {allowedPrompts.map((p, i) => (
+              <li key={i}>{p.prompt}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="hyo-plan-review-buttons">
+        <button
+          className="hyo-plan-review-reject"
+          onClick={() => onRespond(requestId, "deny")}
+        >
+          Reject
+        </button>
+        <button
+          className="hyo-plan-review-approve"
+          onClick={() => onRespond(requestId, "allow")}
+        >
+          Approve plan
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StreamingMessage.tsx
+++ b/src/components/StreamingMessage.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ToolCall } from "./ToolCall";
 import { PermissionRequest } from "./PermissionRequest";
 import { AskQuestion } from "./AskQuestion";
+import { PlanReview } from "./PlanReview";
 import { MarkdownBlock } from "./MarkdownBlock";
 import type { Message } from "../hooks/useChatEngine";
 import { HIDDEN_TOOLS } from "../hooks/useChatEngine";
@@ -9,7 +10,7 @@ import { HIDDEN_TOOLS } from "../hooks/useChatEngine";
 interface StreamingMessageProps {
   message: Message;
   onPermissionResponse: (requestId: string, behavior: "allow" | "allow_always" | "deny") => void;
-  onQuestionAnswer: (questionId: string, answer: string) => void;
+  onQuestionAnswer: (questionId: string, answers: Record<string, string>) => void;
 }
 
 export function StreamingMessage({
@@ -90,6 +91,13 @@ export function StreamingMessage({
           />
         )}
 
+        {message.planReview && !message.planReview.resolved && (
+          <PlanReview
+            review={message.planReview}
+            onRespond={onPermissionResponse}
+          />
+        )}
+
         {activityLabel && (
           <div className="hyo-activity-indicator">
             <span className="hyo-thinking-dot" />
@@ -115,6 +123,9 @@ function getActivityLabel(message: Message): string | null {
 
   if (permissionRequest && !permissionRequest.resolved) return null;
   if (askQuestion) return null;
+
+  const planReview = message.planReview;
+  if (planReview && !planReview.resolved) return null;
 
   const pendingAgent = toolCalls.find(
     (t) => (t.name === "Agent" || t.name === "Task") && !t.result

--- a/src/hooks/useChatEngine.ts
+++ b/src/hooks/useChatEngine.ts
@@ -21,6 +21,7 @@ export interface Message {
   streaming?: boolean;
   permissionRequest?: PermissionRequestData | null;
   askQuestion?: AskQuestionData | null;
+  planReview?: PlanReviewData | null;
   isCompaction?: boolean;
   attachments?: { type: string; name: string; preview?: string }[];
 }
@@ -50,8 +51,15 @@ export interface PermissionRequestData {
 
 export interface AskQuestionData {
   id: string;
-  questions: { question: string; header?: string; options?: { label: string; description?: string }[] }[];
+  questions: { question: string; header?: string; options?: { label: string; description?: string }[]; multiSelect?: boolean }[];
   answers: Record<string, string>;
+}
+
+export interface PlanReviewData {
+  requestId: string;
+  planContent: string | null;
+  allowedPrompts: { tool: string; prompt: string }[];
+  resolved?: "approved" | "rejected";
 }
 
 interface StreamState {
@@ -70,12 +78,33 @@ interface ChatEngineOptions {
   maxOutputTokens?: number;
 }
 
+function readPlanFile(cwd: string): string | null {
+  try {
+    const fs = require("fs");
+    const path = require("path");
+    const candidates = [
+      path.join(cwd, ".claude", "plan.md"),
+      path.join(cwd, "plan.md"),
+    ];
+    for (const p of candidates) {
+      if (fs.existsSync(p)) {
+        return fs.readFileSync(p, "utf-8");
+      }
+    }
+  } catch {
+    // File system not available or file not found
+  }
+  return null;
+}
+
 export function useChatEngine(options: ChatEngineOptions) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [generating, setGenerating] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
 
   const transportRef = useRef<ClaudeTransport | null>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
   const streamRef = useRef<StreamState>({
     toolCalls: [],
     orderedBlocks: [],
@@ -135,17 +164,47 @@ export function useChatEngine(options: ChatEngineOptions) {
         const req = event.request || {};
         const toolName = req.tool_name || "";
         const requestId = event.request_id || "";
+        console.log("[hyo][ask] control_request:", toolName, "requestId:", requestId);
 
-        // AskUserQuestion — auto-approve and surface the question
+        // AskUserQuestion — hold the control_request. DON'T respond.
+        // The CLI blocks waiting for our control_response.
+        // The question UI was set by the assistant event handler.
+        // Update the id to the requestId so sendQuestionAnswer can
+        // send the control_response when the user answers.
         if (toolName === "AskUserQuestion") {
-          transportRef.current?.sendPermissionResponse(requestId, true);
+          console.log("[hyo][ask] Holding AskUserQuestion control_request (NOT auto-approving). requestId:", requestId);
           const input = req.input || {};
-          const askQuestion: AskQuestionData = {
-            id: requestId,
-            questions: input.questions || [{ question: input.question }],
-            answers: {},
-          };
-          updateLastAssistant(() => ({ askQuestion }));
+          updateLastAssistant((msg) => ({
+            askQuestion: msg.askQuestion
+              ? { ...msg.askQuestion, id: requestId }
+              : {
+                  id: requestId,
+                  questions: input.questions || [{ question: input.question }],
+                  answers: {},
+                },
+          }));
+          return;
+        }
+
+        // EnterPlanMode — auto-approve silently. No user gate needed.
+        if (toolName === "EnterPlanMode") {
+          transportRef.current?.sendPermissionResponse(requestId, "allow");
+          return;
+        }
+
+        // ExitPlanMode — show plan review UI with plan content.
+        // Claude is blocked until the user approves or rejects the plan.
+        if (toolName === "ExitPlanMode") {
+          const cwd = optionsRef.current.cwd;
+          const planContent = readPlanFile(cwd);
+          const allowedPrompts = req.input?.allowedPrompts || [];
+          updateLastAssistant(() => ({
+            planReview: {
+              requestId,
+              planContent,
+              allowedPrompts,
+            },
+          }));
           return;
         }
 
@@ -169,7 +228,12 @@ export function useChatEngine(options: ChatEngineOptions) {
       // User event (tool results sent back by the system)
       if (event.type === "user") {
         const contentArr = event.message?.content || [];
-        console.log("[hyo] user event blocks:", contentArr.map((b: any) => b.type));
+        const toolResults = contentArr.filter((b: any) => b.type === "tool_result");
+        console.log("[hyo][ask] user event blocks:", contentArr.map((b: any) => b.type));
+        for (const tr of toolResults) {
+          const matchedTool = ss.toolCalls.find((t) => t.id === tr.tool_use_id);
+          console.log("[hyo][ask] tool_result for:", matchedTool?.name || "unknown", "tool_use_id:", tr.tool_use_id);
+        }
         processContentBlocks(contentArr, ss);
         updateStreamingFromState(ss, updateLastAssistant);
         return;
@@ -178,9 +242,26 @@ export function useChatEngine(options: ChatEngineOptions) {
       // Assistant message (complete)
       if (event.type === "assistant") {
         const contentArr = event.message?.content || [];
-        console.log("[hyo] assistant event blocks:", contentArr.map((b: any) => ({ type: b.type, textPreview: b.type === "text" ? (b.text || "").slice(0, 80) : undefined })));
+        console.log("[hyo] assistant event blocks:", contentArr.map((b: any) => ({ type: b.type, name: b.name, textPreview: b.type === "text" ? (b.text || "").slice(0, 80) : undefined })));
         processContentBlocks(contentArr, ss);
         updateStreamingFromState(ss, updateLastAssistant);
+
+        // Eagerly detect AskUserQuestion from the complete assistant event.
+        // The control_request arrives AFTER this, so we set the question UI
+        // now. The control_request handler will update the id to the requestId.
+        const askTool = ss.toolCalls.find(
+          (t) => t.name === "AskUserQuestion" && !t.result && t.input?.questions
+        );
+        if (askTool) {
+          console.log("[hyo][ask] Detected AskUserQuestion in assistant event. Questions:", askTool.input.questions.length);
+          updateLastAssistant(() => ({
+            askQuestion: {
+              id: askTool.id,
+              questions: askTool.input.questions,
+              answers: {},
+            },
+          }));
+        }
         return;
       }
 
@@ -199,6 +280,7 @@ export function useChatEngine(options: ChatEngineOptions) {
             input: {},
             result: null,
           };
+          console.log("[hyo][ask] tool_use START:", tool.name, tool.id);
           if (!ss.toolCalls.find((t) => t.id === tool.id)) {
             ss.toolCalls.push(tool);
             ss.orderedBlocks.push({
@@ -222,8 +304,36 @@ export function useChatEngine(options: ChatEngineOptions) {
         // Content block stop
         if (evt.type === "content_block_stop") {
           const lastBlock = ss.orderedBlocks[ss.orderedBlocks.length - 1];
+          console.log("[hyo][ask] content_block_stop — lastBlock type:", lastBlock?.type, "toolId:", lastBlock?.toolId);
           if (lastBlock?.type === "tool") {
             ss.toolResultSinceLastText = true;
+
+            const tool = ss.toolCalls[ss.toolCalls.length - 1];
+            console.log("[hyo][ask] content_block_stop for tool:", tool?.name, "id:", tool?.id, "hasInput:", !!tool?.input, "hasQuestions:", !!tool?.input?.questions, "hasInputJson:", !!tool?._inputJson);
+
+            if (tool?.name === "AskUserQuestion") {
+              // Ensure input is fully parsed from accumulated JSON
+              if (tool._inputJson && !tool.input?.questions) {
+                try {
+                  tool.input = JSON.parse(tool._inputJson);
+                  console.log("[hyo][ask] Parsed _inputJson, questions:", !!tool.input?.questions);
+                } catch (e) {
+                  console.log("[hyo][ask] Failed to parse _inputJson:", (e as Error).message);
+                }
+              }
+              if (tool.input?.questions) {
+                console.log("[hyo][ask] ✓ Setting askQuestion and INTERRUPTING. Questions:", tool.input.questions.length);
+                const askQuestion: AskQuestionData = {
+                  id: tool.id,
+                  questions: tool.input.questions,
+                  answers: {},
+                };
+                updateLastAssistant(() => ({ askQuestion }));
+                transportRef.current?.sendInterrupt();
+              } else {
+                console.log("[hyo][ask] ✗ AskUserQuestion but NO questions found. input:", JSON.stringify(tool.input).slice(0, 200));
+              }
+            }
           }
         }
 
@@ -354,45 +464,40 @@ export function useChatEngine(options: ChatEngineOptions) {
   const sendPermissionResponse = useCallback(
     (requestId: string, behavior: "allow" | "allow_always" | "deny") => {
       transportRef.current?.sendPermissionResponse(requestId, behavior);
-      updateLastAssistant((msg) => ({
-        permissionRequest: msg.permissionRequest
-          ? {
-              ...msg.permissionRequest,
-              resolved: behavior === "deny" ? "denied" : "allowed",
-            }
-          : null,
-      }));
+      updateLastAssistant((msg) => {
+        const updates: Partial<Message> = {};
+        if (msg.permissionRequest) {
+          updates.permissionRequest = {
+            ...msg.permissionRequest,
+            resolved: behavior === "deny" ? "denied" : "allowed",
+          };
+        }
+        if (msg.planReview && msg.planReview.requestId === requestId) {
+          updates.planReview = {
+            ...msg.planReview,
+            resolved: behavior === "deny" ? "rejected" : "approved",
+          };
+        }
+        return updates;
+      });
     },
     [updateLastAssistant]
   );
 
   const sendQuestionAnswer = useCallback(
-    (questionId: string, answer: string) => {
-      // Reset stream state for next turn
-      streamRef.current = {
-        toolCalls: [],
-        orderedBlocks: [],
-        turnIndex: 0,
-        toolResultSinceLastText: false,
-        suppressNextTextBlock: false,
-      };
+    (questionId: string, answers: Record<string, string>) => {
+      console.log("[hyo][ask] Sending question answer. requestId:", questionId, "answers:", JSON.stringify(answers));
 
-      updateLastAssistant(() => ({ askQuestion: null, streaming: false }));
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: "assistant",
-          content: "",
-          thinking: "",
-          toolCalls: [],
-          orderedBlocks: [],
-          streaming: true,
-        },
-      ]);
-      setGenerating(true);
+      // Send control_response with answers as updatedInput.
+      // The CLI was blocked on the control_request — this unblocks it.
+      // Claude receives the answers as the tool's input and continues.
+      transportRef.current?.sendPermissionResponse(questionId, "allow", undefined, {
+        answers,
+      });
 
-      // Send the answer as a user message through the transport
-      transportRef.current?.sendUserMessage(answer);
+      // Clear the question UI. The assistant message stays streaming —
+      // Claude will continue and the result event will finalize it.
+      updateLastAssistant(() => ({ askQuestion: null }));
     },
     [updateLastAssistant]
   );

--- a/src/hooks/useSessionManager.ts
+++ b/src/hooks/useSessionManager.ts
@@ -5,6 +5,7 @@ import type {
   ToolCallData,
   OrderedBlock,
   AskQuestionData,
+  PlanReviewData,
 } from "./useChatEngine";
 import { listPastSessions, loadSessionHistory, saveCustomTitle, type PastSession, getProjectDir } from "../session-parser";
 import { repairSession, isThinkingBlockApiError, type RepairResult } from "../session-repair";
@@ -55,6 +56,24 @@ interface SessionManagerOptions {
 }
 
 // ------- utilities -------
+
+function readPlanFile(cwd: string): string | null {
+  try {
+    const fs = require("fs");
+    const planPath = path.join(cwd, ".claude", "plan.md");
+    if (fs.existsSync(planPath)) {
+      return fs.readFileSync(planPath, "utf-8");
+    }
+    // Also check project root
+    const rootPlanPath = path.join(cwd, "plan.md");
+    if (fs.existsSync(rootPlanPath)) {
+      return fs.readFileSync(rootPlanPath, "utf-8");
+    }
+  } catch {
+    // File system not available or file not found
+  }
+  return null;
+}
 
 function genId(): string {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -332,18 +351,56 @@ export function useSessionManager(options: SessionManagerOptions) {
           const toolName = req.tool_name || "";
           const requestId = event.request_id || "";
 
+          // AskUserQuestion — hold the control_request. DON'T respond.
+          // The CLI blocks waiting for our control_response.
+          // The assistant event handler already set askQuestion with the
+          // tool's id. Update it to the requestId so sendQuestionAnswer
+          // can send the control_response when the user answers.
           if (toolName === "AskUserQuestion") {
-            transportsRef.current[tabId]?.sendPermissionResponse(
-              requestId,
-              true
-            );
             const input = req.input || {};
-            const askQuestion: AskQuestionData = {
-              id: requestId,
-              questions: input.questions || [{ question: input.question }],
-              answers: {},
-            };
-            updateTabLastAssistant(tabId, () => ({ askQuestion }));
+            updateTabLastAssistant(tabId, (msg) => ({
+              askQuestion: msg.askQuestion
+                ? { ...msg.askQuestion, id: requestId }
+                : {
+                    id: requestId,
+                    questions: input.questions || [{ question: input.question }],
+                    answers: {},
+                  },
+            }));
+            return;
+          }
+
+          // EnterPlanMode — auto-approve silently. No user gate needed.
+          if (toolName === "EnterPlanMode") {
+            transportsRef.current[tabId]?.sendPermissionResponse(requestId, "allow");
+            return;
+          }
+
+          // ExitPlanMode — show plan review UI with plan content.
+          // Claude is blocked until the user approves or rejects.
+          if (toolName === "ExitPlanMode") {
+            // Get plan content: first try the Write tool call that created
+            // the plan (the content is right there in the input), then fall
+            // back to reading from disk.
+            let planContent: string | null = null;
+            const writeCalls = ss.toolCalls.filter(
+              (t) => t.name === "Write" && t.input?.content
+            );
+            if (writeCalls.length > 0) {
+              planContent = writeCalls[writeCalls.length - 1].input.content;
+            }
+            if (!planContent) {
+              planContent = readPlanFile(options.cwd);
+            }
+
+            const allowedPrompts = req.input?.allowedPrompts || [];
+            updateTabLastAssistant(tabId, () => ({
+              planReview: {
+                requestId,
+                planContent,
+                allowedPrompts,
+              },
+            }));
             return;
           }
 
@@ -374,49 +431,51 @@ export function useSessionManager(options: SessionManagerOptions) {
             ),
           }));
 
-          // Auto-generate title after first response if enabled
+          // Auto-generate title after first response
           if (options.autoGenerateTitles) {
             const currentTab = stateRef.current.tabs.find((t) => t.id === tabId);
-            if (
-              currentTab &&
-              currentTab.messages.length === 2 &&
-              currentTab.messages[0]?.role === "user" &&
-              currentTab.messages[1]?.role === "assistant" &&
-              !currentTab.messages[1]?.isCompaction
-            ) {
-              const userText =
-                currentTab.messages[0].displayText ||
-                (typeof currentTab.messages[0].content === "string"
-                  ? currentTab.messages[0].content
-                  : "");
-              const truncatedTitle =
-                userText.slice(0, 40) + (userText.length > 40 ? "..." : "");
+            if (currentTab && currentTab.messages.length >= 2) {
+              const firstUser = currentTab.messages.find((m) => m.role === "user" && !m.isCompaction);
+              const firstAssistant = currentTab.messages.find((m) => m.role === "assistant" && !m.isCompaction);
 
-              // Only generate if title is still the auto-truncated version
-              if (
-                currentTab.title === truncatedTitle ||
-                currentTab.title === "New conversation"
-              ) {
-                const titleBeforeGeneration = currentTab.title;
+              if (firstUser && firstAssistant) {
+                const userText =
+                  firstUser.displayText ||
+                  (typeof firstUser.content === "string" ? firstUser.content : "");
+                const truncatedTitle =
+                  userText.slice(0, 40) + (userText.length > 40 ? "..." : "");
 
-                generateConversationTitle({
-                  cliPath: options.cliPath,
-                  userMessage: userText,
-                  assistantMessage:
-                    typeof currentTab.messages[1].content === "string"
-                      ? currentTab.messages[1].content
-                      : "",
-                }).then((generatedTitle) => {
-                  if (!generatedTitle) return;
+                // Only generate if title hasn't been manually set
+                const needsTitle =
+                  currentTab.title === "New conversation" ||
+                  currentTab.title === truncatedTitle;
 
-                  // Check tab still exists and title hasn't been manually changed
-                  const tab = stateRef.current.tabs.find((t) => t.id === tabId);
-                  if (!tab || tab.title !== titleBeforeGeneration) return;
+                if (needsTitle && userText) {
+                  const titleBeforeGeneration = currentTab.title;
+                  const assistantText =
+                    typeof firstAssistant.content === "string"
+                      ? firstAssistant.content
+                      : "";
 
-                  renameTab(tabId, generatedTitle);
-                }).catch((err) => {
-                  console.error("[hyo] Title generation error:", err);
-                });
+                  console.log("[hyo][title] Generating for tab", tabId);
+
+                  generateConversationTitle({
+                    cliPath: options.cliPath,
+                    userMessage: userText,
+                    assistantMessage: assistantText,
+                  }).then((generatedTitle) => {
+                    if (!generatedTitle) {
+                      console.warn("[hyo][title] Generation returned null");
+                      return;
+                    }
+                    const tab = stateRef.current.tabs.find((t) => t.id === tabId);
+                    if (!tab || tab.title !== titleBeforeGeneration) return;
+                    console.log("[hyo][title] Renamed:", generatedTitle);
+                    renameTab(tabId, generatedTitle);
+                  }).catch((err) => {
+                    console.error("[hyo][title] Error:", err);
+                  });
+                }
               }
             }
           }
@@ -457,6 +516,22 @@ export function useSessionManager(options: SessionManagerOptions) {
           const contentArr = event.message?.content || [];
           processContentBlocks(contentArr, ss, "assistant");
           updateTabLastAssistant(tabId, () => buildSnapshot(ss));
+
+          // Eagerly detect AskUserQuestion from the complete assistant event.
+          // The control_request arrives AFTER this, so set the question UI now.
+          // The control_request handler will update the id to the requestId.
+          const askTool = ss.toolCalls.find(
+            (t) => t.name === "AskUserQuestion" && !t.result && t.input?.questions
+          );
+          if (askTool) {
+            updateTabLastAssistant(tabId, () => ({
+              askQuestion: {
+                id: askTool.id,
+                questions: askTool.input.questions,
+                answers: {},
+              },
+            }));
+          }
           return;
         }
 
@@ -782,58 +857,44 @@ export function useSessionManager(options: SessionManagerOptions) {
       const lastMsg = tab?.messages[tab.messages.length - 1];
       const toolName = lastMsg?.permissionRequest?.toolName;
       transportsRef.current[tabId]?.sendPermissionResponse(requestId, behavior, toolName);
-      updateTabLastAssistant(tabId, (msg) => ({
-        permissionRequest: msg.permissionRequest
-          ? {
-              ...msg.permissionRequest,
-              resolved: behavior === "deny" ? ("denied" as const) : ("allowed" as const),
-            }
-          : null,
-      }));
+      updateTabLastAssistant(tabId, (msg) => {
+        const updates: Partial<Message> = {};
+        if (msg.permissionRequest) {
+          updates.permissionRequest = {
+            ...msg.permissionRequest,
+            resolved: behavior === "deny" ? ("denied" as const) : ("allowed" as const),
+          };
+        }
+        // Also resolve planReview if this requestId matches
+        if (msg.planReview && msg.planReview.requestId === requestId) {
+          updates.planReview = {
+            ...msg.planReview,
+            resolved: behavior === "deny" ? ("rejected" as const) : ("approved" as const),
+          };
+        }
+        return updates;
+      });
     },
     [updateTabLastAssistant]
   );
 
   const sendQuestionAnswer = useCallback(
-    (questionId: string, answer: string) => {
+    (questionId: string, answers: Record<string, string>) => {
       const tabId = stateRef.current.activeTabId;
 
-      streamStatesRef.current[tabId] = {
-        toolCalls: [],
-        orderedBlocks: [],
-        turnIndex: 0,
-        toolResultSinceLastText: false,
-        skillResultPending: false,
-      };
+      // Send control_response with answers as updatedInput.
+      // The CLI was blocked on the control_request — this unblocks it.
+      // Claude receives the answers and continues within the same turn.
+      transportsRef.current[tabId]?.sendPermissionResponse(
+        questionId,
+        "allow",
+        undefined,
+        { answers }
+      );
 
-      updateTabLastAssistant(tabId, () => ({
-        askQuestion: null,
-        streaming: false,
-      }));
-      setState((prev) => ({
-        ...prev,
-        tabs: prev.tabs.map((tab) =>
-          tab.id !== tabId
-            ? tab
-            : {
-                ...tab,
-                messages: [
-                  ...tab.messages,
-                  {
-                    role: "assistant" as const,
-                    content: "",
-                    thinking: "",
-                    toolCalls: [],
-                    orderedBlocks: [],
-                    streaming: true,
-                  },
-                ],
-                generating: true,
-              }
-        ),
-      }));
-
-      transportsRef.current[tabId]?.sendUserMessage(answer);
+      // Clear the question UI. The assistant message stays streaming —
+      // Claude will continue and the result event will finalize it.
+      updateTabLastAssistant(tabId, () => ({ askQuestion: null }));
     },
     [updateTabLastAssistant]
   );

--- a/src/hooks/useUsage.ts
+++ b/src/hooks/useUsage.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { requestUrl } from "obsidian";
 
 // Type definitions for the usage API response
 export interface UsageData {
@@ -35,105 +36,84 @@ interface OAuthCreds {
  */
 async function getOAuthCreds(): Promise<OAuthCreds | null> {
   try {
-    const { exec } = require("child_process");
-    const { promisify } = require("util");
-    const execAsync = promisify(exec);
-    const username: string = require("os").userInfo().username;
-    const { stdout } = await execAsync(
-      `security find-generic-password -s "Claude Code-credentials" -a "${username}" -w`,
-      { timeout: 5000, maxBuffer: 1024 * 1024 }
-    );
-    const raw = stdout.trim();
+    const fs = require("fs");
+    const path = require("path");
+    const home = require("os").homedir();
+    const credsPath = path.join(home, ".claude", ".credentials.json");
 
-    // Try normal JSON parse first
-    try {
-      const creds = JSON.parse(raw);
-      return creds?.claudeAiOauth || null;
-    } catch {
-      // Keychain value may be truncated — extract OAuth tokens via regex
-      const accessMatch = raw.match(/"accessToken"\s*:\s*"([^"]+)"/);
-      const refreshMatch = raw.match(/"refreshToken"\s*:\s*"([^"]+)"/);
-      if (accessMatch) {
-        return {
-          accessToken: accessMatch[1],
-          refreshToken: refreshMatch?.[1] || undefined,
-        };
-      }
+    const raw = fs.readFileSync(credsPath, "utf-8");
+    const creds = JSON.parse(raw);
+
+    if (!creds?.claudeAiOauth) {
+      console.warn("[hyo][usage] No claudeAiOauth in credentials file");
       return null;
     }
-  } catch {
+
+    const oauth = creds.claudeAiOauth;
+    if (!oauth.accessToken) {
+      console.warn("[hyo][usage] No accessToken in credentials");
+      return null;
+    }
+
+    return oauth;
+  } catch (e: any) {
+    console.warn("[hyo][usage] Credentials read failed:", e?.message || e);
     return null;
   }
 }
 
 /**
- * Make an HTTPS request using Node's https module (avoids CORS in Obsidian renderer)
- */
-function httpsRequest(
-  url: string,
-  options: { method?: string; headers?: Record<string, string>; body?: string }
-): Promise<{ status: number; body: string }> {
-  return new Promise((resolve, reject) => {
-    const https = require("https");
-    const urlObj = new URL(url);
-    const reqOptions = {
-      hostname: urlObj.hostname,
-      path: urlObj.pathname + urlObj.search,
-      method: options.method || "GET",
-      headers: options.headers || {},
-    };
-    const req = https.request(reqOptions, (res: any) => {
-      let data = "";
-      res.on("data", (chunk: Buffer) => { data += chunk.toString(); });
-      res.on("end", () => resolve({ status: res.statusCode, body: data }));
-    });
-    req.on("error", reject);
-    if (options.body) req.write(options.body);
-    req.end();
-  });
-}
-
-/**
- * Refresh the OAuth access token
+ * Refresh the OAuth access token using Obsidian's requestUrl
  */
 async function refreshOAuthToken(
   refreshToken: string
 ): Promise<string | null> {
   try {
-    const body = JSON.stringify({
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      client_id: "claude-code",
-    });
-    const res = await httpsRequest("https://claude.ai/api/oauth/token", {
+    const res = await requestUrl({
+      url: "https://claude.ai/api/oauth/token",
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body,
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: "claude-code",
+      }),
+      throw: false,
     });
-    if (res.status !== 200) return null;
-    const data = JSON.parse(res.body);
-    return data.access_token || null;
-  } catch {
+    if (res.status !== 200) {
+      console.warn("[hyo][usage] Token refresh failed:", res.status);
+      return null;
+    }
+    return res.json?.access_token || null;
+  } catch (e: any) {
+    console.warn("[hyo][usage] Token refresh error:", e?.message || e);
     return null;
   }
 }
 
 /**
- * Fetch usage data from the Anthropic API
+ * Fetch usage data from the Anthropic API using Obsidian's requestUrl
  */
 async function fetchUsageWithToken(
   token: string
 ): Promise<{ status: number; data: UsageData | null }> {
   try {
-    const res = await httpsRequest("https://api.anthropic.com/api/oauth/usage", {
+    const res = await requestUrl({
+      url: "https://api.anthropic.com/api/oauth/usage",
+      method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
         "anthropic-beta": "oauth-2025-04-20",
       },
+      throw: false,
     });
-    if (res.status !== 200) return { status: res.status, data: null };
-    return { status: 200, data: JSON.parse(res.body) };
-  } catch {
+    if (res.status !== 200) {
+      console.warn("[hyo][usage] API returned status:", res.status);
+      return { status: res.status, data: null };
+    }
+    return { status: 200, data: res.json };
+  } catch (e: any) {
+    console.warn("[hyo][usage] API request error:", e?.message || e);
     return { status: 0, data: null };
   }
 }
@@ -143,22 +123,37 @@ async function fetchUsageWithToken(
  */
 async function fetchUsage(): Promise<UsageData | null> {
   const creds = await getOAuthCreds();
-  if (!creds?.accessToken) return null;
+  if (!creds?.accessToken) {
+    console.warn("[hyo][usage] No credentials available");
+    return null;
+  }
 
   try {
     // Try with current token
     let result = await fetchUsageWithToken(creds.accessToken);
 
     // If expired, refresh and retry
-    if (result.status === 401 && creds.refreshToken) {
-      const newToken = await refreshOAuthToken(creds.refreshToken);
-      if (newToken) {
-        result = await fetchUsageWithToken(newToken);
+    if (result.status === 401) {
+      console.log("[hyo][usage] Got 401 — refreshToken?", !!creds.refreshToken, "type:", typeof creds.refreshToken, "len:", creds.refreshToken?.length);
+      if (creds.refreshToken) {
+        console.log("[hyo][usage] Attempting token refresh...");
+        const newToken = await refreshOAuthToken(creds.refreshToken);
+        if (newToken) {
+          console.log("[hyo][usage] Refresh succeeded, retrying...");
+          result = await fetchUsageWithToken(newToken);
+        } else {
+          console.warn("[hyo][usage] Refresh returned null");
+        }
       }
     }
 
+    if (result.data) {
+      console.log("[hyo][usage] Fetch OK — 5hr:", result.data.five_hour?.utilization, "7d:", result.data.seven_day?.utilization);
+    }
+
     return result.data;
-  } catch {
+  } catch (e: any) {
+    console.warn("[hyo][usage] fetchUsage error:", e?.message || e);
     return null;
   }
 }
@@ -192,6 +187,7 @@ function calcWeeklyPacePct(resetsAt: string | undefined): number | null {
 export function useUsage() {
   const [usage, setUsage] = useState<UsageData | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [stale, setStale] = useState(false);
 
   const poll = useCallback(async () => {
     try {
@@ -199,10 +195,13 @@ export function useUsage() {
       if (data) {
         setUsage(data);
         setLastUpdated(new Date());
+        setStale(false);
       } else {
+        setStale(true);
         console.warn("[hyo] Usage fetch returned null — check keychain or token");
       }
     } catch (e) {
+      setStale(true);
       console.error("[hyo] Usage fetch failed:", e);
     }
   }, []);
@@ -211,6 +210,13 @@ export function useUsage() {
     poll();
     const interval = setInterval(poll, 300000); // 5 minutes
     return () => clearInterval(interval);
+  }, [poll]);
+
+  // Re-poll when window regains visibility (catches stale token after long idle)
+  useEffect(() => {
+    const onVisible = () => { if (document.visibilityState === "visible") poll(); };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
   }, [poll]);
 
   const sessionPct = usage?.five_hour
@@ -230,6 +236,7 @@ export function useUsage() {
     sessionPacePct,
     weeklyPacePct,
     lastUpdated,
+    stale,
     refresh: poll,
   };
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,7 +27,7 @@ export const DEFAULT_SETTINGS: HyoSettings = {
   workingDirectory: "",
   defaultAgent: "",
   maxOutputTokens: 64000,
-  autoGenerateTitles: false,
+  autoGenerateTitles: true,
   // Voice
   elevenLabsApiKey: "",
   voiceId: "",

--- a/src/title-generator.ts
+++ b/src/title-generator.ts
@@ -13,15 +13,17 @@ function truncate(text: string, max: number): string {
 }
 
 function buildPrompt(userMsg: string, assistantMsg: string): string {
-  const u = truncate(userMsg.trim(), 500);
-  const a = truncate(assistantMsg.trim(), 500);
+  const u = truncate(userMsg.trim(), 300);
+  const a = truncate(assistantMsg.trim(), 300);
   return [
-    "Generate a concise, descriptive title (maximum 6 words) for this conversation.",
-    "Return ONLY the title text — no quotes, no prefix, no formatting.",
+    "TASK: Generate a short title (3-6 words) that describes what this conversation is about.",
+    "RULES: Output ONLY the title. No quotes. No explanation. No preamble. Just the title words.",
     "",
-    `User: ${u}`,
+    "CONVERSATION:",
+    `<user>${u}</user>`,
+    `<assistant>${a}</assistant>`,
     "",
-    `Assistant: ${a}`,
+    "TITLE:",
   ].join("\n");
 }
 
@@ -82,9 +84,10 @@ export async function generateConversationTitle(
       process.env.PATH || "",
     ].join(":");
 
-    console.log("[hyo] Generating conversation title...");
+    console.log("[hyo][title] Spawning CLI for title generation...");
 
     const proc = spawn(cliPath, args, {
+      cwd: "/tmp",
       env,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -93,10 +96,10 @@ export async function generateConversationTitle(
     let stderr = "";
 
     const timeout = setTimeout(() => {
-      console.log("[hyo] Title generation timed out after 10s");
+      console.warn("[hyo][title] Timed out after 30s");
       proc.kill("SIGTERM");
       resolve(null);
-    }, 10_000);
+    }, 30_000);
 
     proc.stdout?.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
@@ -108,7 +111,7 @@ export async function generateConversationTitle(
 
     proc.on("error", (err) => {
       clearTimeout(timeout);
-      console.error("[hyo] Title generation spawn error:", err.message);
+      console.error("[hyo][title] Spawn error:", err.message);
       resolve(null);
     });
 
@@ -117,10 +120,10 @@ export async function generateConversationTitle(
 
       if (code !== 0) {
         console.error(
-          "[hyo] Title generation failed (code",
+          "[hyo][title] CLI exited with code",
           code,
-          "):",
-          stderr.slice(0, 200),
+          "| stderr:",
+          stderr.slice(0, 300),
         );
         resolve(null);
         return;
@@ -128,9 +131,9 @@ export async function generateConversationTitle(
 
       const title = cleanTitle(stdout);
       if (title) {
-        console.log("[hyo] Generated title:", title);
+        console.log("[hyo][title] Generated:", title);
       } else {
-        console.log("[hyo] Title generation returned empty response");
+        console.warn("[hyo][title] CLI returned empty response");
       }
       resolve(title);
     });

--- a/styles.css
+++ b/styles.css
@@ -495,104 +495,291 @@
 }
 
 /* Ask question */
-.hyo-ask-question {
+/* ── AskQuestion ── */
+
+.hyo-ask {
   margin: 12px 0;
-  padding: 12px 14px;
-  border: 1px solid var(--background-modifier-border);
-  border-radius: var(--radius-m);
-  background: var(--background-secondary);
-}
-
-.hyo-ask-question-header {
-  font-weight: 600;
-  font-size: 12px;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 4px;
-}
-
-.hyo-ask-question-text {
-  font-size: 14px;
-  margin-bottom: 10px;
-}
-
-.hyo-ask-question-answered {
-  padding: 6px 10px;
-  background: var(--interactive-accent);
-  color: var(--text-on-accent);
-  border-radius: var(--radius-s);
-  font-size: 13px;
-  display: inline-block;
-}
-
-.hyo-ask-question-options {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: 12px;
 }
 
-.hyo-ask-option {
+.hyo-ask-item {
+  padding: 14px 16px;
+  border-radius: var(--radius-m);
+  background: var(--background-secondary);
+  border-left: 3px solid var(--interactive-accent);
+}
+
+.hyo-ask-item.is-answered {
+  border-left-color: var(--text-faint);
+  opacity: 0.7;
+}
+
+.hyo-ask-item.is-pending {
+  border-left-color: var(--background-modifier-border);
+  opacity: 0.4;
+}
+
+.hyo-ask-item-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  min-height: 20px;
+}
+
+.hyo-ask-chip {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--interactive-accent);
+  background: rgba(var(--interactive-accent-rgb, 72, 120, 208), 0.1);
+  padding: 2px 8px;
+  border-radius: 10px;
+  line-height: 1.4;
+}
+
+.hyo-ask-answered-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.hyo-ask-answered-badge svg {
+  color: var(--text-success, var(--interactive-accent));
+  flex-shrink: 0;
+}
+
+.hyo-ask .hyo-ask-question-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-normal);
+  margin: 0 0 12px 0;
+  line-height: 1.45;
+}
+
+.hyo-ask-item.is-answered .hyo-ask-question-text {
+  margin-bottom: 0;
+}
+
+/* Controls container */
+.hyo-ask-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* Option buttons */
+.hyo-ask-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+button.hyo-ask-opt {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding: 8px 12px;
-  border: 1px solid var(--background-modifier-border);
-  border-radius: var(--radius-s);
-  background: var(--background-primary);
+  padding: 7px 14px;
+  border: none;
+  border-left: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
   color: var(--text-normal);
   cursor: pointer;
   font-size: 13px;
   text-align: left;
   width: 100%;
+  transition: all 0.1s ease;
+  height: auto;
 }
 
-.hyo-ask-option:hover {
-  background: var(--background-modifier-hover);
-  border-color: var(--interactive-accent);
+button.hyo-ask-opt:hover {
+  background: rgba(var(--interactive-accent-rgb, 72, 120, 208), 0.06);
+  border-left-color: var(--interactive-accent);
 }
 
-.hyo-ask-option-desc {
+button.hyo-ask-opt:active {
+  background: rgba(var(--interactive-accent-rgb, 72, 120, 208), 0.1);
+}
+
+.hyo-ask-opt-label {
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.hyo-ask-opt-desc {
   font-size: 11px;
   color: var(--text-muted);
   margin-top: 2px;
+  line-height: 1.4;
 }
 
-.hyo-ask-or {
-  text-align: center;
+/* Divider */
+.hyo-ask-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   color: var(--text-faint);
-  font-size: 12px;
+  font-size: 11px;
 }
 
-.hyo-ask-text-input {
+.hyo-ask-divider::before,
+.hyo-ask-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--background-modifier-border);
+}
+
+/* Text input */
+.hyo-ask-input {
   display: flex;
   gap: 6px;
+  align-items: center;
 }
 
-.hyo-ask-text-input input {
+.hyo-ask-input input {
   flex: 1;
-  padding: 6px 10px;
+  padding: 7px 12px;
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--radius-s);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
+  transition: border-color 0.15s ease;
 }
 
-.hyo-ask-text-input button {
-  padding: 6px 12px;
+.hyo-ask-input input:focus {
+  outline: none;
+  border-color: var(--interactive-accent);
+  box-shadow: 0 0 0 2px rgba(var(--interactive-accent-rgb, 72, 120, 208), 0.15);
+}
+
+button.hyo-ask-send {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
   border: none;
   border-radius: var(--radius-s);
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   cursor: pointer;
-  font-size: 12px;
+  flex-shrink: 0;
+  transition: background 0.15s ease, opacity 0.15s ease;
 }
 
-.hyo-ask-text-input button:disabled {
-  opacity: 0.5;
+button.hyo-ask-send:hover:not(:disabled) {
+  background: var(--interactive-accent-hover);
+}
+
+button.hyo-ask-send:disabled {
+  opacity: 0.35;
   cursor: default;
+}
+
+/* Plan review */
+.hyo-plan-review {
+  margin: 12px 0;
+  padding: 14px 16px;
+  border: 1px solid var(--interactive-accent);
+  border-radius: var(--radius-m);
+  background: var(--background-secondary);
+}
+
+.hyo-plan-review-resolved {
+  border-color: var(--background-modifier-border);
+  padding: 8px 14px;
+}
+
+.hyo-plan-review-status {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.hyo-plan-review-header {
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 10px;
+  color: var(--text-normal);
+}
+
+.hyo-plan-review-content {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  background: var(--background-primary);
+  font-size: 13px;
+}
+
+.hyo-plan-review-fallback {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+  font-style: italic;
+}
+
+.hyo-plan-review-permissions {
+  margin-bottom: 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.hyo-plan-review-permissions-label {
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.hyo-plan-review-permissions ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.hyo-plan-review-permissions li {
+  margin: 2px 0;
+}
+
+.hyo-plan-review-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.hyo-plan-review-buttons button {
+  padding: 6px 16px;
+  border-radius: var(--radius-s);
+  border: 1px solid var(--background-modifier-border);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.hyo-plan-review-reject {
+  background: var(--background-primary);
+  color: var(--text-muted);
+}
+
+.hyo-plan-review-reject:hover {
+  background: var(--background-modifier-hover);
+}
+
+.hyo-plan-review-approve {
+  background: var(--interactive-accent) !important;
+  color: var(--text-on-accent) !important;
+  border-color: var(--interactive-accent) !important;
+}
+
+.hyo-plan-review-approve:hover {
+  background: var(--interactive-accent-hover) !important;
 }
 
 /* Streaming state */
@@ -1091,6 +1278,12 @@
   background: var(--background-modifier-hover);
 }
 
+.hyo-usage-bars-group.stale .hyo-usage-bar-fill,
+.hyo-usage-bars-group.stale .hyo-usage-bar-label,
+.hyo-usage-bars-group.stale .hyo-usage-bar-track {
+  opacity: 0.45;
+}
+
 .hyo-usage-bar-label {
   font-size: 10px;
   color: var(--text-faint);
@@ -1421,6 +1614,13 @@
 .hyo-usage-refresh-btn:hover {
   color: var(--text-normal);
   background: var(--background-modifier-hover);
+}
+
+.hyo-usage-stale-notice {
+  padding: 6px 8px;
+  font-size: 11px;
+  color: #f39c12;
+  line-height: 1.4;
 }
 
 /* Model popup */


### PR DESCRIPTION
## Summary

- **AskUserQuestion**: Claude now pauses and waits for user answers instead of steamrolling through. Redesigned UI with option buttons, free-text input, multi-question support, and polished styling.
- **Plan mode**: EnterPlanMode auto-approves silently. ExitPlanMode shows actual plan content (from Write tool calls) with approve/reject buttons.
- **Usage monitor**: Fixed — replaced macOS `security` CLI (which truncates at ~2KB) with direct file read from `~/.claude/.credentials.json`. Cross-platform, no keychain prompts.
- **Auto-naming**: Fixed title generation — runs from `/tmp` to avoid loading CLAUDE.md, 30s timeout, restructured prompt so Haiku generates titles not responses.

## Test plan

- [ ] Send a message that triggers AskUserQuestion — verify Claude pauses and waits for answer
- [ ] Enter plan mode — verify plan content shows with approve/reject
- [ ] Check usage popup — should show real percentages
- [ ] New conversation tab — title should auto-generate after first response

🤖 Generated with [Claude Code](https://claude.com/claude-code)